### PR TITLE
Fix: PDF merge categorization by ensuring data availability

### DIFF
--- a/.changeset/fix-pdf-categorization.md
+++ b/.changeset/fix-pdf-categorization.md
@@ -1,0 +1,7 @@
+---
+"sacred-sutra-tools": patch
+---
+
+Fix PDF merge categorization by ensuring products and categories are loaded before processing
+
+This change ensures that both products and categories are fetched from the store before PDF merge operations begin, preventing race conditions that could cause products to not be categorized properly during the merge process.


### PR DESCRIPTION
## 📋 Description
Fixes the issue where PDF merge operations could fail to properly categorize products due to race conditions in data loading.

Changes in this PR:
- b333f9c fix: no categories on pdf
- c65a921 chore: add changeset for PDF categorization fix

## 🔄 Type of Change
- [x] 🐛 Bug fix (patch)
- [ ] ✨ New feature (minor)
- [ ] 💥 Breaking change (major)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring/maintenance
- [ ] 🧪 Test updates

## 🦋 Changeset Required?
- [x] **Yes** - This change affects users and requires a changeset
- [ ] **No** - This is internal/maintenance work (tests, docs, refactoring)

### ✅ Changeset Created
A **patch** changeset has been automatically created and committed:
```
Fix PDF merge categorization by ensuring products and categories are loaded before processing

This change ensures that both products and categories are fetched from the store before PDF merge operations begin, preventing race conditions that could cause products to not be categorized properly during the merge process.
```

## 🧪 Testing
- [x] Tests added/updated for the changes
- [x] All existing tests pass
- [x] Manual testing completed

## 📝 Additional Notes
🐛 **BUG FIX**: This fixes the issue where the system wasn't able to categorize products when merging PDFs due to categories and products not being loaded before the merge operation began.

### Technical Details
- Enhanced `previewCategoryDeductions` and `mergePDFs` async thunks in `pdfMergerSlice.ts`
- Added automatic fetching of both products and categories if they're not already loaded
- Prevents race conditions by ensuring data availability before PDF processing
- Maintains backward compatibility with existing functionality

### Impact
- Products will now be properly categorized during PDF merge operations
- Eliminates the timing-dependent failures in product categorization
- Improves reliability of inventory deduction calculations
- Ensures consistent behavior regardless of when the operation is triggered

---

### Pre-merge Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changeset created (automatically generated)
- [x] Tests pass locally
- [x] No console errors/warnings
- [x] Documentation updated (if needed)